### PR TITLE
Add static docs website

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DyoGrid Architecture</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+  <h1>Architecture Overview</h1>
+</header>
+<nav>
+  <a href="index.html">Home</a>
+  <a href="quickstart.html">Quickstart</a>
+  <a href="architecture.html">Architecture</a>
+</nav>
+<main>
+<p>DyoGrid is organized into several components. The repository contains a Python backend, a React-based frontend, and optional agent controller services. Below is a high-level overview.</p>
+<h2>Backend</h2>
+<p>The backend provides FastAPI endpoints and utilities for orchestrating agents.</p>
+<ul>
+<li><code>main.py</code> &ndash; FastAPI application with endpoints for chat and file uploads.</li>
+<li><code>magentic_one_custom_agent.py</code> &ndash; example of a custom agent implementation.</li>
+<li><code>orchestration_utils.py</code> &ndash; helper class for stopping agent loops when tasks are done.</li>
+<li><code>llm_config.py</code> &ndash; reads environment variables to configure LLM providers such as Azure OpenAI or an Ollama proxy.</li>
+</ul>
+<h2>Frontend</h2>
+<p>The frontend is built with React, Vite and Tailwind CSS. It offers a chat interface and agent management UI.</p>
+<ul>
+<li>To develop locally, run <code>npm install</code> and <code>npm run dev</code> inside <code>frontend/</code>.</li>
+<li>The build output can be deployed to static hosting or used with Azure Static Web Apps.</li>
+</ul>
+<h2>MCP Server</h2>
+<p>The <code>mcp/</code> directory contains an example remote MCP server using FastAPI and SSE transport. It can be run with <code>uv run fastapi dev main.py</code>.</p>
+</main>
+<footer>
+  <p>&copy; 2024 DyoGrid</p>
+</footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DyoGrid Documentation</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+  <h1>\ud83e\uddd0 DyoGrid</h1>
+</header>
+<nav>
+  <a href="index.html">Home</a>
+  <a href="quickstart.html">Quickstart</a>
+  <a href="architecture.html">Architecture</a>
+</nav>
+<main>
+<h2>Open-source Platform for LLM Agents</h2>
+<p><strong>DyoGrid</strong> is an open-source, modular platform for orchestrating teams of intelligent agents powered by large language models. It lets you build agent-based workflows that integrate with your existing systems&mdash;ERPs, CRMs, databases, and IoT platforms&mdash;with full governance, observability, and extensibility.</p>
+<h3>\ud83d\udea8 The Problem</h3>
+<ul>
+<li><strong>Shadow AI</strong> &ndash; isolated experiments create duplication and security gaps.</li>
+<li><strong>Integration Pain</strong> &ndash; connecting LLMs to enterprise systems takes weeks of brittle code.</li>
+<li><strong>Vendor Lock-In</strong> &ndash; proprietary platforms limit flexibility and control.</li>
+<li><strong>No Observability</strong> &ndash; poor insight into agent behavior, cost, and outcome quality.</li>
+</ul>
+<h3>\u2705 The DyoGrid Solution</h3>
+<ul>
+<li><strong>Agent Fabric</strong> &ndash; pluggable LLM agent modules compatible with Autogen-style interactions.</li>
+<li><strong>Team Orchestrator</strong> &ndash; DAG-style coordination with retry logic, stop rules and budget caps.</li>
+<li><strong>Integration Mesh</strong> &ndash; connectors and SDKs for REST, databases, Kafka, RPA, and more.</li>
+<li><strong>Governance Layer</strong> &ndash; RBAC, telemetry, cost metering and traceability.</li>
+<li><strong>Developer UX</strong> &ndash; visual flows via low-code canvas or advanced scripting via SDK/CLI.</li>
+</ul>
+<h3>\ud83d\udd0d Use Cases</h3>
+<table>
+<tr><th>Use Case</th><th>Description</th></tr>
+<tr><td>Autonomous Support Agents</td><td>Integrate with Zendesk, Salesforce, or Freshdesk</td></tr>
+<tr><td>Finance Ops Automation</td><td>Query ERP, reconcile reports, generate insights</td></tr>
+<tr><td>Smart Factory Agents</td><td>Analyze IoT logs via OPC-UA + LLM for diagnostics</td></tr>
+<tr><td>R&amp;D Workflows</td><td>Agents collaborating on patent research or document review</td></tr>
+<tr><td>Compliance Audits</td><td>Validate controls by querying internal logs and systems</td></tr>
+</table>
+<h3>\ud83c\udf0d Industries Supported</h3>
+<ul>
+<li>Enterprise SaaS / IT</li>
+<li>Manufacturing / IIoT</li>
+<li>Finance &amp; Accounting</li>
+<li>Logistics &amp; Supply Chain</li>
+<li>Customer Support / BPO</li>
+<li>Research &amp; Knowledge Work</li>
+</ul>
+</main>
+<footer>
+  <p>&copy; 2024 DyoGrid</p>
+</footer>
+</body>
+</html>

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DyoGrid Quickstart</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+  <h1>Quickstart</h1>
+</header>
+<nav>
+  <a href="index.html">Home</a>
+  <a href="quickstart.html">Quickstart</a>
+  <a href="architecture.html">Architecture</a>
+</nav>
+<main>
+<h2>Prerequisites</h2>
+<ul>
+<li>Python 3.10 or higher</li>
+<li>Docker (optional for local LLMs)</li>
+<li>Node.js (optional for the low-code canvas)</li>
+</ul>
+<h2>Installation</h2>
+<pre><code>git clone https://github.com/dyogrid/dyogrid.git
+cd dyogrid
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+</code></pre>
+<h2>Running the Backend</h2>
+<pre><code>uv venv
+source .venv/bin/activate
+uv sync
+playwright install --with-deps chromium
+uvicorn main:app --reload
+</code></pre>
+<h2>Running the Frontend</h2>
+<pre><code>cd frontend
+npm install
+npm run dev
+</code></pre>
+<p>This will start the development server at <code>http://localhost:3000</code>.</p>
+</main>
+<footer>
+  <p>&copy; 2024 DyoGrid</p>
+</footer>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,9 @@
+body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;line-height:1.6;background:#f4f4f4;color:#333}
+header{background:#222;color:#fff;padding:20px 0;text-align:center}
+nav{background:#444;color:#fff;padding:10px;text-align:center}
+nav a{color:#fff;margin:0 10px;text-decoration:none;font-weight:bold}
+nav a:hover{text-decoration:underline}
+main{max-width:800px;margin:20px auto;padding:20px;background:#fff}
+footer{background:#222;color:#fff;text-align:center;padding:10px 0;margin-top:20px}
+code,pre{background:#eee;padding:2px 4px;border-radius:4px}
+pre{overflow-x:auto}


### PR DESCRIPTION
## Summary
- add simple documentation site in `docs/`
- include home page content, quickstart guide, and architecture overview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844124f663c8328b18501d8d2d2badf