### PR TITLE
Add configurable OpenAI timeout

### DIFF
--- a/backend/llm_config.py
+++ b/backend/llm_config.py
@@ -6,6 +6,7 @@ def get_llm_provider():
 
 def get_llm_config():
     provider = get_llm_provider()
+    timeout = int(os.getenv("OPENAI_TIMEOUT", 60))
 
     if provider == "azure":
         return {
@@ -14,6 +15,7 @@ def get_llm_config():
             "base_url": os.getenv("AZURE_OPENAI_ENDPOINT"),
             "api_key": os.getenv("AZURE_OPENAI_API_KEY"),
             "api_version": os.getenv("AZURE_OPENAI_API_VERSION", "2023-05-15"),
+            "timeout": timeout,
         }
     elif provider == "ollama":
         return {
@@ -23,7 +25,8 @@ def get_llm_config():
             "api_key": os.getenv("LITELLM_API_KEY", "sk-no-key-needed"),
             "function_calling": "auto",
             "json_output": True,
-            "stream": True
+            "stream": True,
+            "timeout": timeout,
         }
     else:
         raise ValueError(f"Unsupported provider: {provider}")

--- a/backend/magentic_one_custom_agent.py
+++ b/backend/magentic_one_custom_agent.py
@@ -14,13 +14,14 @@ def _build_llm_client():
     Supports 'azure' and 'openai' (incl. LiteLLM/Ollama proxy) providers.
     """
     cfg = get_llm_config().copy()
+    timeout = cfg.pop("timeout", 60)
     provider = cfg.pop("provider", "openai").lower()
 
     if provider == "azure":
-        return AzureOpenAIChatCompletionClient(**cfg)
+        return AzureOpenAIChatCompletionClient(timeout=timeout, **cfg)
     else:
         # treat every non‑azure provider as OpenAI compatible
-        return OpenAIChatCompletionClient(**cfg)
+        return OpenAIChatCompletionClient(timeout=timeout, **cfg)
 
 class MagenticOneCustomAgent(AssistantAgent):
     """Custom agent without function calling support."""

--- a/backend/magentic_one_helper.py
+++ b/backend/magentic_one_helper.py
@@ -234,6 +234,7 @@ class MagenticOneHelper:
                 "azure_endpoint": self.llm_config["base_url"],
                 "azure_ad_token_provider": token_provider,
                 "api_key": self.llm_config["api_key"],
+                "timeout": self.llm_config.get("timeout", 60),
             }
             self.client = AzureOpenAIChatCompletionClient(**azure_args)
             # Reasoning client can override model/deployment if needed; here we reuse same
@@ -249,7 +250,8 @@ class MagenticOneHelper:
                 model_info=self.llm_config.get(
                     "model_info",
                     {"vision": False, "function_calling": True, "json_output": True, "family": "ollama"}
-                )
+                ),
+                timeout=self.llm_config.get("timeout", 60),
             )
             self.client_reasoning = OpenAIChatCompletionClient(
                 model=self.llm_config["model"],
@@ -260,7 +262,8 @@ class MagenticOneHelper:
                 model_info=self.llm_config.get(
                     "model_info",
                     {"vision": False, "function_calling": True, "json_output": True, "family": "ollama"}
-                )
+                ),
+                timeout=self.llm_config.get("timeout", 60),
             )
         else:
             raise RuntimeError(f"Unsupported LLM provider: {provider}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -129,7 +129,8 @@ async def get_openai_client():
         api_version="2024-12-01-preview",
         # azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
         # azure_endpoint="https://aoai-eastus-mma-cdn.openai.azure.com/",
-        azure_ad_token_provider=token_provider
+        azure_ad_token_provider=token_provider,
+        timeout=int(os.getenv("OPENAI_TIMEOUT", 60))
     )
 
 

--- a/backend/sample1.env
+++ b/backend/sample1.env
@@ -24,3 +24,6 @@ MCP_SERVER_API_KEY=1234
 RAG_BACKEND=faiss
 
 DEBUG_AGENT_LOGS=true
+
+# Timeout for OpenAI API requests (seconds)
+OPENAI_TIMEOUT=60


### PR DESCRIPTION
## Summary
- allow configuring timeout via `OPENAI_TIMEOUT` env variable
- pass timeout to `OpenAIChatCompletionClient` and `AzureOpenAIChatCompletionClient`
- use timeout for AsyncAzureOpenAI client
- provide example OPENAI_TIMEOUT in `sample1.env`

## Testing
- `python -m py_compile backend/llm_config.py backend/magentic_one_helper.py backend/magentic_one_custom_agent.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844371291dc8328a97b839a417b7e2d