### PR TITLE
Use local embeddings with FAISS

### DIFF
--- a/backend/magentic_one_helper.py
+++ b/backend/magentic_one_helper.py
@@ -39,6 +39,8 @@ token_provider = get_bearer_token_provider(
     azure_credential, "https://cognitiveservices.azure.com/.default"
 )
 
+RAG_BACKEND = os.getenv("RAG_BACKEND", "azure").lower()
+
 def _wrap_with_proxy(agent):
     """
     Attach a unique AgentId (id/name + key) to every agent so that
@@ -367,15 +369,16 @@ class MagenticOneHelper:
             elif (agent["type"] == "RAG"):
                 # RAG agent
                 rag_agent = MagenticOneRAGAgent(
-                    agent["name"], 
-                    model_client=client, 
+                    agent["name"],
+                    model_client=client,
                     index_name=agent["index_name"],
                     description=agent["description"],
                     AZURE_SEARCH_SERVICE_ENDPOINT=os.getenv("AZURE_SEARCH_SERVICE_ENDPOINT"),
-                    use_azure_search=False, 
+                    use_azure_search=False,
                     # AZURE_SEARCH_ADMIN_KEY=os.getenv("AZURE_SEARCH_ADMIN_KEY")
                     )
-                rag_agent.load_faiss_data(docs)
+                if RAG_BACKEND == "faiss":
+                    rag_agent.load_faiss_data(docs)
                 agent_list.append(_wrap_with_proxy(rag_agent))
                 print(f'{agent["name"]} (RAG) added!')
             else:


### PR DESCRIPTION
## Summary
- allow choosing FAISS backend via `RAG_BACKEND`
- build FAISS indices for uploaded documents
- load FAISS data only when using local backend

## Testing
- `python -m py_compile backend/aisearch.py backend/magentic_one_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_684442b24a40832897b8b18c44d04cc2