### PR TITLE
Fix conversation data path

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -3,7 +3,9 @@ import os, json, uuid
 from datetime import datetime
 from typing import List
 
-DATA_DIR = "./data/conversations"
+# Store conversation data relative to this file so the service works
+# regardless of the working directory used to launch it.
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data", "conversations")
 
 def ensure_data_dir():
     if not os.path.exists(DATA_DIR):


### PR DESCRIPTION
## Summary
- fix conversation storage path to be relative to backend package

## Testing
- `python -m py_compile backend/crud.py`


------
https://chatgpt.com/codex/tasks/task_e_68445d7f7d288328a81b968ac7219465