### PR TITLE
Fix OpenAI config for Autogen client

### DIFF
--- a/backend/llm_config.py
+++ b/backend/llm_config.py
@@ -61,6 +61,9 @@ def build_chat_client(agent_name: str | None = None, agent_type: str | None = No
     timeout = cfg.pop("timeout", 60)
     provider = cfg.pop("provider", "openai").lower()
 
+    # Filter out unsupported args for the client constructor
+    cfg.pop("stream", None)
+
     if provider == "azure":
         return AzureOpenAIChatCompletionClient(timeout=timeout, **cfg)
     else:


### PR DESCRIPTION
## Summary
- filter out unsupported `stream` parameter when constructing chat clients

## Testing
- `python -m py_compile backend/llm_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68447a349ff483288c1d751d457b80bf