### PR TITLE
Fix invalid model error for custom models

### DIFF
--- a/backend/llm_config.py
+++ b/backend/llm_config.py
@@ -44,6 +44,13 @@ def get_llm_config(agent_name: str | None = None, agent_type: str | None = None)
             "function_calling": "auto",
             "json_output": True,
             "stream": True,
+            # Required when using a non-OpenAI model via LiteLLM/Ollama
+            "model_info": {
+                "family": "ollama",
+                "function_calling": True,
+                "json_output": True,
+                "vision": False,
+            },
             "timeout": timeout,
         }
     else:


### PR DESCRIPTION
## Summary
- include a default `model_info` in `get_llm_config` when using the ollama provider so OpenAIChatCompletionClient accepts non-standard model names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68447adb69bc8328b2fec7e7905a33e4