### PR TITLE
Fix case insensitive agent model map

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,14 @@ pip install litellm
 pip install 'litellm[proxy]'
  litellm --config litellm.config.yaml
 
-Set the `AGENT_MODEL_MAP` environment variable to map agent names to specific models, e.g.
+Set the `AGENT_MODEL_MAP` environment variable to map agent names to specific models.  
+Agent names are matched case-insensitively.
+You can always enable function-calling support for custom models by setting `LITELLM_ALWAYS_ENABLE_TOOLS=true`.
+Example:
 
 ```bash
 export AGENT_MODEL_MAP="Coder:ollama/deepseek-coder:6.7b,WebSurfer:ollama/llama3.1"
+export LITELLM_ALWAYS_ENABLE_TOOLS=true
 ```
 
 

--- a/backend/sample1.env
+++ b/backend/sample1.env
@@ -17,6 +17,8 @@ LITELLM_BASE_URL=http://localhost:4000/v1
 LITELLM_API_KEY=sk-no-key-needed
 OLLAMA_MODEL=ollama/llama3.1
 AGENT_MODEL_MAP=Coder:ollama/deepseek-coder:6.7b,Executor:ollama/deepseek-coder:6.7b
+# Enable tool calling for mapped models
+LITELLM_ALWAYS_ENABLE_TOOLS=true
 
 MCP_SERVER_URI=http://localhost:8333
 MCP_SERVER_MODE=stdio


### PR DESCRIPTION
## Summary
- allow case-insensitive agent names when reading `AGENT_MODEL_MAP`
- add option `LITELLM_ALWAYS_ENABLE_TOOLS` so tool calling works with custom models
- document new variable and behaviour in README and sample env

## Testing
- `python -m py_compile backend/llm_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6844a00339608328b09a3f8171476ec5