### PR TITLE
Add AutoGenBench integration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -667,6 +667,51 @@ async def run_bench(payload: dict):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@app.post("/bench/run_team")
+async def run_bench_team(payload: dict):
+    """Run AutoGenBench for a specific team and store results."""
+    try:
+        team_id = payload.get("team_id")
+        scenario = payload.get("scenario")
+        repeats = int(payload.get("repeats", 1))
+        config_path = payload.get("config")
+        results_dir = payload.get("results_dir", "bench_results")
+        subsample = payload.get("subsample")
+
+        from autogenbench.run_cmd import run_scenarios
+        from autogen import config_list_from_json
+        import io, contextlib
+        from autogenbench.tabulate_cmd import default_tabulate
+
+        config_list = config_list_from_json(env_or_file=config_path)
+        run_scenarios(
+            scenario=scenario,
+            n_repeats=repeats,
+            is_native=True,
+            config_list=config_list,
+            requirements=None,
+            results_dir=results_dir,
+            subsample=float(subsample) if subsample is not None else None,
+        )
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            default_tabulate(["bench", results_dir, "--csv"])
+        csv = buffer.getvalue()
+
+        app.state.db.store_bench_result({
+            "team_id": team_id,
+            "scenario": scenario,
+            "results_dir": results_dir,
+            "csv": csv,
+            "timestamp": time.time(),
+        })
+
+        return {"status": "completed", "results_dir": results_dir, "csv": csv}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @app.get("/bench/results")
 async def bench_results(results_dir: str = Query("bench_results")):
     """Return tabulated benchmark results."""
@@ -678,5 +723,15 @@ async def bench_results(results_dir: str = Query("bench_results")):
         with contextlib.redirect_stdout(buffer):
             default_tabulate(["bench", results_dir, "--csv"])
         return {"csv": buffer.getvalue()}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/bench/team/{team_id}")
+async def bench_results_team(team_id: str):
+    """Fetch stored benchmark results for a team."""
+    try:
+        results = app.state.db.get_bench_results(team_id)
+        return results
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/src/pages/Bench.tsx
+++ b/frontend/src/pages/Bench.tsx
@@ -45,13 +45,16 @@ export default function Bench() {
   const runBench = async () => {
     try {
       setRunning(true);
-      await axios.post(`${BASE_URL}/bench/run`, {
+      await axios.post(`${BASE_URL}/bench/run_team`, {
+        team_id: selectedTeam.team_id,
         scenario: "scenarios/basic.jsonl",
         config: "OAI_CONFIG_LIST.json",
         repeats: 1
       });
-      const res = await axios.get(`${BASE_URL}/bench/results`);
-      setOutput(res.data.csv);
+      const res = await axios.get(`${BASE_URL}/bench/team/${selectedTeam.team_id}`);
+      if (Array.isArray(res.data) && res.data.length > 0) {
+        setOutput(res.data[0].csv);
+      }
     } catch (err) {
       console.error(err);
     } finally {


### PR DESCRIPTION
## Summary
- add new DB helpers for storing benchmark results
- expose backend endpoints for running benchmarks for teams and retrieving results
- update bench page to call new API

## Testing
- `python -m py_compile backend/*.py`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684ddf2028588328b8794a4a8feebb35